### PR TITLE
fix versionCode regex

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	// versionCode — A positive integer [...] -> https://developer.android.com/studio/publish/versioning
-	versionCodeRegexPattern = `^versionCode(?:\s|=)*(.*?)(?:\s|\/\/|$)`
+	versionCodeRegexPattern = `^versionCode(?:\s|=)+(.*?)(?:\s|\/\/|$)`
 	// versionName — A string used as the version number shown to users [...] -> https://developer.android.com/studio/publish/versioning
 	versionNameRegexPattern = `^versionName(?:=|'|"|\s)+(.*?)(?:'|"|\s|\/\/|$)`
 )


### PR DESCRIPTION
### Checklist

- [x] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires PATCH [version update](https://semver.org/)

I'm not tied to the kind of version update this requires. I think a regex change like this is probably patch since it is a bug fix for currently expected functionality. There are probably few people misusing this since it probably creates compile errors.

### Context

Address issues related to `versionCodes` variable being incorrectly replaced in React Native projects.

To address issues 

Resolves: #21 

### Changes

- Improved regular expression used to match `versionCode`

### PR

I'm having the same problem and see that @boreal-is already found a solution. Simply creating the PR request so hopefully it can be merged for the rest of us 😬 