### PR TITLE
Fix version code regex

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -23,10 +23,12 @@ workflows:
         inputs:
         - path: ./_tmp
         - is_create_path: true
-    - script:
-        title: clone sample app
+    - git::https://github.com/bitrise-steplib/bitrise-step-simple-git-clone.git:
+        title: Clone test project
         inputs:
-        - content: git clone -b master $SAMPLE_APP_REPOSITORY_URL ./
+        - clone_into_dir: $BITRISE_SOURCE_DIR
+        - repository_url: $SAMPLE_APP_REPOSITORY_URL
+        - branch: master
     - path::./:
         title: step test
         inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -41,8 +41,8 @@ workflows:
         - content: |-
             #!/usr/bin/env bash
             set -x
-            if [[ "${ANDROID_VERSION_NAME}" != "2.0" ]]; then
-                echo "Invalid ANDROID_VERSION_NAME, should be: 2.0"
+            if [[ "${ANDROID_VERSION_NAME}" != '"2.0"' ]]; then
+                echo 'Invalid ANDROID_VERSION_NAME, should be: "2.0"'
                 exit 1
             elif (( ${ANDROID_VERSION_CODE} != 2 )); then
                 echo "Invalid ANDROID_VERSION_CODE, should be: 2"
@@ -63,8 +63,8 @@ workflows:
             #!/usr/bin/env bash
             set -x
 
-            if [[ "${ANDROID_VERSION_NAME}" != "4.0" ]]; then
-                echo "Invalid ANDROID_VERSION_NAME, should be: 4.0"
+            if [[ "${ANDROID_VERSION_NAME}" != '"4.0"' ]]; then
+                echo 'Invalid ANDROID_VERSION_NAME, should be: "4.0"'
                 exit 1
             elif (( ${ANDROID_VERSION_CODE} != 4 )); then
                 echo "Invalid ANDROID_VERSION_CODE, should be: 4"

--- a/main.go
+++ b/main.go
@@ -71,20 +71,24 @@ func failf(format string, v ...interface{}) {
 	os.Exit(1)
 }
 
+// BuildGradleVersionUpdater updates versionName and versionCode in the given build.gradle file.
 type BuildGradleVersionUpdater struct {
 	buildGradleReader io.Reader
 }
 
+// NewBuildGradleVersionUpdater constructs a new BuildGradleVersionUpdater.
 func NewBuildGradleVersionUpdater(buildGradleReader io.Reader) BuildGradleVersionUpdater {
 	return BuildGradleVersionUpdater{buildGradleReader: buildGradleReader}
 }
 
+// UpdateResult stors the result of the version update.
 type UpdateResult struct {
 	NewContent                               string
 	FinalVersionCode, FinalVersionName       string
 	UpdatedVersionCodes, UpdatedVersionNames int
 }
 
+// UpdateVersion executes the version updates.
 func (u BuildGradleVersionUpdater) UpdateVersion(newVersionCode *int, versionCodeOffset int, newVersionName *string) (*UpdateResult, error) {
 	res := UpdateResult{}
 	var err error

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	// versionCode — A positive integer [...] -> https://developer.android.com/studio/publish/versioning
-	versionCodeRegexPattern = `^versionCode(?:\s|=)*(.*?)(?:\s|\/\/|$)`
+	versionCodeRegexPattern = `^versionCode(?:\s|=)+(.*?)(?:\s|\/\/|$)`
 	// versionName — A string used as the version number shown to users [...] -> https://developer.android.com/studio/publish/versioning
 	versionNameRegexPattern = `^versionName(?:=|'|"|\s)+(.*?)(?:'|"|\s|\/\/|$)`
 )

--- a/main.go
+++ b/main.go
@@ -119,6 +119,7 @@ func (u BuildGradleVersionUpdater) UpdateVersion(newVersionCode, versionCodeOffs
 			if newVersionName != "" {
 				quotedNewVersionName := newVersionName
 				if !(strings.HasPrefix(quotedNewVersionName, `"`) && strings.HasSuffix(quotedNewVersionName, `"`)) {
+					quotedNewVersionName = strings.TrimPrefix(quotedNewVersionName, `"`)
 					quotedNewVersionName = strings.TrimSuffix(quotedNewVersionName, `"`)
 					quotedNewVersionName = `"` + quotedNewVersionName + `"`
 					log.Warnf(`Leading and/or trailing " character missing from new_version_name, adding quotation char: %s -> %s`, newVersionName, quotedNewVersionName)

--- a/main.go
+++ b/main.go
@@ -23,10 +23,10 @@ const (
 )
 
 type config struct {
-	BuildGradlePth    string  `env:"build_gradle_path,file"`
-	NewVersionName    *string `env:"new_version_name"`
-	NewVersionCode    *int    `env:"new_version_code"`
-	VersionCodeOffset int     `env:"version_code_offset"`
+	BuildGradlePth    string `env:"build_gradle_path,file"`
+	NewVersionName    string `env:"new_version_name"`
+	NewVersionCode    int    `env:"new_version_code,range]0..2100000000]"`
+	VersionCodeOffset int    `env:"version_code_offset"`
 }
 
 type updateFn func(line string, lineNum int, matches []string) string
@@ -147,7 +147,7 @@ func main() {
 	stepconf.Print(cfg)
 	fmt.Println()
 
-	if cfg.NewVersionName == nil && cfg.NewVersionCode == nil {
+	if cfg.NewVersionName == "" && cfg.NewVersionCode == 0 {
 		failf("Neither NewVersionCode nor NewVersionName are provided, however one of them is required.")
 	}
 
@@ -161,20 +161,8 @@ func main() {
 		failf("Failed to read build.gradle file, error: %s", err)
 	}
 
-	// versionCode — A positive integer used as an internal version number.
-	// https://developer.android.com/studio/publish/versioning#appversioning
-	newVersionCode := 0
-	if cfg.NewVersionCode != nil {
-		newVersionCode = *cfg.NewVersionCode
-	}
-
-	newVersionName := ""
-	if cfg.NewVersionName != nil {
-		newVersionName = *cfg.NewVersionName
-	}
-
 	versionUpdater := NewBuildGradleVersionUpdater(f)
-	res, err := versionUpdater.UpdateVersion(newVersionCode, cfg.VersionCodeOffset, newVersionName)
+	res, err := versionUpdater.UpdateVersion(cfg.NewVersionCode, cfg.VersionCodeOffset, cfg.NewVersionName)
 	if err != nil {
 		failf("Failed to update versions: %s", err)
 	}

--- a/main.go
+++ b/main.go
@@ -114,7 +114,13 @@ func (u BuildGradleVersionUpdater) UpdateVersion(newVersionCode *int, versionCod
 			updatedLine := ""
 
 			if newVersionName != nil {
-				res.FinalVersionName = *newVersionName
+				quotedNewVersionName := *newVersionName
+				if !(strings.HasPrefix(quotedNewVersionName, `"`) && strings.HasSuffix(quotedNewVersionName, `"`)) {
+					quotedNewVersionName = strings.TrimSuffix(quotedNewVersionName, `"`)
+					quotedNewVersionName = `"` + quotedNewVersionName + `"`
+					log.Warnf(`Leading and/or trailing " character missing from new_version_name, adding quotation char: %s -> %s`, *newVersionName, quotedNewVersionName)
+				}
+				res.FinalVersionName = quotedNewVersionName
 				updatedLine = strings.Replace(line, oldVersionName, res.FinalVersionName, -1)
 				res.UpdatedVersionNames++
 				log.Printf("updating line (%d): %s -> %s", lineNum, line, updatedLine)

--- a/main_test.go
+++ b/main_test.go
@@ -116,8 +116,14 @@ func TestBuildGradleVersionUpdater_UpdateVersion(t *testing.T) {
 		{
 			name:              "Updates versionName variable",
 			buildGradleReader: strings.NewReader("versionName rootProject.ext.versionName"),
-			newVersionName:    pointers.NewStringPtr("1.1.0"),
-			want:              &UpdateResult{NewContent: `versionName "1.1.0"`, FinalVersionName: "1.1.0", UpdatedVersionNames: 1},
+			newVersionName:    pointers.NewStringPtr(`"1.1.0"`),
+			want:              &UpdateResult{NewContent: `versionName "1.1.0"`, FinalVersionName: `"1.1.0"`, UpdatedVersionNames: 1},
+		},
+		{
+			name:              "Updates versionName variable - newVersionName withouth quotation char",
+			buildGradleReader: strings.NewReader("versionName rootProject.ext.versionName"),
+			newVersionName:    pointers.NewStringPtr(`1.1.0`),
+			want:              &UpdateResult{NewContent: `versionName "1.1.0"`, FinalVersionName: `"1.1.0"`, UpdatedVersionNames: 1},
 		},
 		{
 			name:              "Does not touch ABI version code mapping",

--- a/main_test.go
+++ b/main_test.go
@@ -7,8 +7,6 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-
-	"github.com/bitrise-io/go-utils/pointers"
 )
 
 func Test_typeConv(t *testing.T) {
@@ -26,6 +24,7 @@ func Test_regexPatterns(t *testing.T) {
 		want          string
 		regexPattern  string
 	}{
+		// versionCode regex
 		{`versionCode 1`, "1", versionCodeRegexPattern},
 		{`versionCode 1//close comment`, "1", versionCodeRegexPattern},
 		{`versionCode 1 // far comment`, "1", versionCodeRegexPattern},
@@ -54,26 +53,27 @@ func Test_regexPatterns(t *testing.T) {
 		{`versionCode   =  myWar//close comment` + "\n", "myWar", versionCodeRegexPattern},
 		{`versionCode  = myWar // far comment` + "\n", "myWar", versionCodeRegexPattern},
 
-		{`versionName "1.0"`, "1.0", versionNameRegexPattern},
-		{`versionName "1.0"//close comment`, "1.0", versionNameRegexPattern},
-		{`versionName "1.0" // far comment`, "1.0", versionNameRegexPattern},
-		{`versionName '1.0'`, "1.0", versionNameRegexPattern},
-		{`versionName '1.0'//close comment`, "1.0", versionNameRegexPattern},
-		{`versionName '1.0' // far comment`, "1.0", versionNameRegexPattern},
-		{`versionName = '1.0' // far comment`, "1.0", versionNameRegexPattern},
+		// versionName regex
+		{`versionName "1.0"`, `"1.0"`, versionNameRegexPattern},
+		{`versionName "1.0"//close comment`, `"1.0"`, versionNameRegexPattern},
+		{`versionName "1.0" // far comment`, `"1.0"`, versionNameRegexPattern},
+		{`versionName '1.0'`, `'1.0'`, versionNameRegexPattern},
+		{`versionName '1.0'//close comment`, `'1.0'`, versionNameRegexPattern},
+		{`versionName '1.0' // far comment`, `'1.0'`, versionNameRegexPattern},
+		{`versionName = '1.0' // far comment`, `'1.0'`, versionNameRegexPattern},
 
 		{`versionName myWar`, "myWar", versionNameRegexPattern},
 		{`versionName myWar//close comment`, "myWar", versionNameRegexPattern},
 		{`versionName myWar // far comment`, "myWar", versionNameRegexPattern},
 		{`versionName = myWar // far comment`, "myWar", versionNameRegexPattern},
 
-		{`versionName "1.0"` + "\n", "1.0", versionNameRegexPattern},
-		{`versionName "1.0"//close comment` + "\n", "1.0", versionNameRegexPattern},
-		{`versionName="1.0" // far comment` + "\n", "1.0", versionNameRegexPattern},
-		{`versionName '1.0'` + "\n", "1.0", versionNameRegexPattern},
-		{`versionName '1.0'//close comment` + "\n", "1.0", versionNameRegexPattern},
-		{`versionName '1.0' // far comment` + "\n", "1.0", versionNameRegexPattern},
-		{`versionName = '1.0' // far comment` + "\n", "1.0", versionNameRegexPattern},
+		{`versionName "1.0"` + "\n", `"1.0"`, versionNameRegexPattern},
+		{`versionName "1.0"//close comment` + "\n", `"1.0"`, versionNameRegexPattern},
+		{`versionName="1.0" // far comment` + "\n", `"1.0"`, versionNameRegexPattern},
+		{`versionName '1.0'` + "\n", `'1.0'`, versionNameRegexPattern},
+		{`versionName '1.0'//close comment` + "\n", `'1.0'`, versionNameRegexPattern},
+		{`versionName '1.0' // far comment` + "\n", `'1.0'`, versionNameRegexPattern},
+		{`versionName = '1.0' // far comment` + "\n", `'1.0'`, versionNameRegexPattern},
 
 		{`versionName myWar` + "\n", "myWar", versionNameRegexPattern},
 		{`versionName myWar//close comment` + "\n", "myWar", versionNameRegexPattern},
@@ -85,14 +85,16 @@ func Test_regexPatterns(t *testing.T) {
 		{`versionName myWar // far comment` + "\n", "myWar", versionNameRegexPattern},
 		{`versionName=myWar // far comment` + "\n", "myWar", versionNameRegexPattern},
 	} {
-		got := regexp.MustCompile(tt.regexPattern).FindStringSubmatch(tt.sampleContent)
-		if len(got) == 0 {
-			t.Errorf("regex(%s) didn't match for content: %s\n\n got: %s", tt.regexPattern, tt.sampleContent, got)
-			return
-		}
-		if got[1] != tt.want {
-			t.Errorf("got: (%v), want: (%v)", got[1], tt.want)
-		}
+		t.Run(tt.sampleContent, func(t *testing.T) {
+			got := regexp.MustCompile(tt.regexPattern).FindStringSubmatch(tt.sampleContent)
+			if len(got) == 0 {
+				t.Errorf("regex(%s) didn't match for content: %s\n\n got: %s", tt.regexPattern, tt.sampleContent, got)
+				return
+			}
+			if got[1] != tt.want {
+				t.Errorf("got: (%v), want: (%v)", got[1], tt.want)
+			}
+		})
 	}
 }
 
@@ -100,42 +102,74 @@ func TestBuildGradleVersionUpdater_UpdateVersion(t *testing.T) {
 	tests := []struct {
 		name              string
 		buildGradleReader io.Reader
-		newVersionCode    *int
+		newVersionCode    int
 		versionCodeOffset int
-		newVersionName    *string
+		newVersionName    string
 
-		want    *UpdateResult
+		want    UpdateResult
 		wantErr bool
 	}{
+		// versionCode update
+		{
+			name:              "Updates versionCode value",
+			buildGradleReader: strings.NewReader("versionCode 1"),
+			newVersionCode:    555,
+			want:              UpdateResult{NewContent: "versionCode 555", FinalVersionCode: "555", UpdatedVersionCodes: 1},
+		},
 		{
 			name:              "Updates versionCode variable",
 			buildGradleReader: strings.NewReader("versionCode rootProject.ext.versionCode"),
-			newVersionCode:    pointers.NewIntPtr(555),
-			want:              &UpdateResult{NewContent: "versionCode 555", FinalVersionCode: "555", UpdatedVersionCodes: 1},
+			newVersionCode:    555,
+			want:              UpdateResult{NewContent: "versionCode 555", FinalVersionCode: "555", UpdatedVersionCodes: 1},
 		},
 		{
-			name:              "Updates versionName variable",
-			buildGradleReader: strings.NewReader("versionName rootProject.ext.versionName"),
-			newVersionName:    pointers.NewStringPtr(`"1.1.0"`),
-			want:              &UpdateResult{NewContent: `versionName "1.1.0"`, FinalVersionName: `"1.1.0"`, UpdatedVersionNames: 1},
-		},
-		{
-			name:              "Updates versionName variable - newVersionName withouth quotation char",
-			buildGradleReader: strings.NewReader("versionName rootProject.ext.versionName"),
-			newVersionName:    pointers.NewStringPtr(`1.1.0`),
-			want:              &UpdateResult{NewContent: `versionName "1.1.0"`, FinalVersionName: `"1.1.0"`, UpdatedVersionNames: 1},
+			name:              "versionCode needs to be a positive integer",
+			buildGradleReader: strings.NewReader("versionCode 1"),
+			newVersionCode:    0,
+			want:              UpdateResult{NewContent: "versionCode 1", FinalVersionCode: "1"},
 		},
 		{
 			name:              "Does not touch ABI version code mapping",
 			buildGradleReader: strings.NewReader(`def versionCodes = ["armeabi-v7a": 1, "x86": 2, "arm64-v8a": 3, "x86_64": 4]`),
-			newVersionCode:    pointers.NewIntPtr(555),
-			want:              &UpdateResult{NewContent: `def versionCodes = ["armeabi-v7a": 1, "x86": 2, "arm64-v8a": 3, "x86_64": 4]`},
+			newVersionCode:    555,
+			want:              UpdateResult{NewContent: `def versionCodes = ["armeabi-v7a": 1, "x86": 2, "arm64-v8a": 3, "x86_64": 4]`},
 		},
 		{
 			name:              "Does not touch per ABI version selector",
 			buildGradleReader: strings.NewReader(`versionCodes.get(abi) * 1000 + defaultConfig.versionCode`),
-			newVersionCode:    pointers.NewIntPtr(555),
-			want:              &UpdateResult{NewContent: `versionCodes.get(abi) * 1000 + defaultConfig.versionCode`},
+			newVersionCode:    555,
+			want:              UpdateResult{NewContent: `versionCodes.get(abi) * 1000 + defaultConfig.versionCode`},
+		},
+		// versionName update
+		{
+			name:              "Updates versionName value with single quote",
+			buildGradleReader: strings.NewReader(`versionName "0.9.0"`),
+			newVersionName:    `"1.1.0"`,
+			want:              UpdateResult{NewContent: `versionName "1.1.0"`, FinalVersionName: `"1.1.0"`, UpdatedVersionNames: 1},
+		},
+		{
+			name:              "Updates versionName value with double quote",
+			buildGradleReader: strings.NewReader(`versionName '0.9.0'`),
+			newVersionName:    `"1.1.0"`,
+			want:              UpdateResult{NewContent: `versionName "1.1.0"`, FinalVersionName: `"1.1.0"`, UpdatedVersionNames: 1},
+		},
+		{
+			name:              "Updates versionName variable",
+			buildGradleReader: strings.NewReader("versionName rootProject.ext.versionName"),
+			newVersionName:    `"1.1.0"`,
+			want:              UpdateResult{NewContent: `versionName "1.1.0"`, FinalVersionName: `"1.1.0"`, UpdatedVersionNames: 1},
+		},
+		{
+			name:              "versionName needs to be a not empty string",
+			buildGradleReader: strings.NewReader(`versionName "1.0.0"`),
+			newVersionName:    "",
+			want:              UpdateResult{NewContent: `versionName "1.0.0"`, FinalVersionName: `"1.0.0"`},
+		},
+		{
+			name:              "Adds quotation mark to newVersionName if missing",
+			buildGradleReader: strings.NewReader("versionName rootProject.ext.versionName"),
+			newVersionName:    `1.1.0`,
+			want:              UpdateResult{NewContent: `versionName "1.1.0"`, FinalVersionName: `"1.1.0"`, UpdatedVersionNames: 1},
 		},
 	}
 	for _, tt := range tests {

--- a/main_test.go
+++ b/main_test.go
@@ -171,6 +171,18 @@ func TestBuildGradleVersionUpdater_UpdateVersion(t *testing.T) {
 			newVersionName:    `1.1.0`,
 			want:              UpdateResult{NewContent: `versionName "1.1.0"`, FinalVersionName: `"1.1.0"`, UpdatedVersionNames: 1},
 		},
+		{
+			name:              "Adds quotation mark to newVersionName if leading is missing",
+			buildGradleReader: strings.NewReader("versionName rootProject.ext.versionName"),
+			newVersionName:    `1.1.0"`,
+			want:              UpdateResult{NewContent: `versionName "1.1.0"`, FinalVersionName: `"1.1.0"`, UpdatedVersionNames: 1},
+		},
+		{
+			name:              "Adds quotation mark to newVersionName if traling is missing",
+			buildGradleReader: strings.NewReader("versionName rootProject.ext.versionName"),
+			newVersionName:    `"1.1.0`,
+			want:              UpdateResult{NewContent: `versionName "1.1.0"`, FinalVersionName: `"1.1.0"`, UpdatedVersionNames: 1},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -174,9 +174,7 @@ func TestBuildGradleVersionUpdater_UpdateVersion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			u := BuildGradleVersionUpdater{
-				buildGradleReader: tt.buildGradleReader,
-			}
+			u := NewBuildGradleVersionUpdater(tt.buildGradleReader)
 			got, err := u.UpdateVersion(tt.newVersionCode, tt.versionCodeOffset, tt.newVersionName)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("BuildGradleVersionUpdater.UpdateVersion() error = %v, wantErr %v", err, tt.wantErr)

--- a/step.yml
+++ b/step.yml
@@ -63,48 +63,28 @@ inputs:
       title: New versionName
       summary: |-
         New versionName to set.
-
-        For example: 1.0.0
-        
-        Leave this input empty so that versionName remains unchanged.
       description: |-
-        New versionName to set.
-
-        For example: 1.0.0
-        
+        New versionName to set.  
+        Specify a string value, such as `"1.0.0"`.  
+        If the specified value is not surranded by double quote (`"`) characters, the step will add them.  
         Leave this input empty so that versionName remains unchanged.
   - new_version_code: $BITRISE_BUILD_NUMBER
     opts:
       title: New versionCode
       summary: |-
         New versionCode to set.
-
-        For example: 1
-        
-        Leave this input empty to do not modify versionCode. 
       description: |-
-        New versionCode to set.
-
-        For example: 1
-        
-        Leave this input empty so that versionCode remains unchanged. 
+        New versionCode to set.  
+        Specify a positive integer value, such as `1`.  
+        Leave this input empty so that versionCode remains unchanged.
   - version_code_offset:
     opts:
       title: versionCode Offset
       summary: |-
-        Offset value for versionCode.
-
-        For example: 1
-
-        Leave this input empty if you want the exact value you set in
-        `New versionCode` input otherwise it will be added to it.
+        Offset value to add to `New versionCode`.
       description: |-
-        Offset value for versionCode.
-
-        For example: 1
-
-        Leave this input empty if you want the exact value you set in
-        `New versionCode` input otherwise it will be added to it.
+        Offset value to add to `New versionCode`, for example: `1`.  
+        Leave this input empty if you want the exact value you set in `New versionCode` input.
 outputs:
   - ANDROID_VERSION_NAME:
     opts:

--- a/step.yml
+++ b/step.yml
@@ -76,6 +76,7 @@ inputs:
       description: |-
         New versionCode to set.  
         Specify a positive integer value, such as `1`.  
+        The greatest value Google Play allows for versionCode is 2100000000.  
         Leave this input empty so that versionCode remains unchanged.
   - version_code_offset:
     opts:


### PR DESCRIPTION
### Checklist

- [x] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _PATCH_ [version update](https://semver.org/)

### Context

This PR resolves version update-related bugs.


Resolves: https://github.com/bitrise-steplib/steps-change-android-versioncode-and-versionname/issues/11 and https://github.com/bitrise-steplib/steps-change-android-versioncode-and-versionname/issues/21

### Changes

- Separate versionCode and versionName update related functionality into `BuildGradleVersionUpdater` struct and `UpdateVersion` function.
- Add unit tests to reproduce version update bugs
- Updated versionCodeRegexPattern and versionNameRegexPattern

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->
