### PR TITLE
Remove unnecessary quotation marks from the version name output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 _tmp/
 .bitrise*
+.idea/

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -43,8 +43,8 @@ workflows:
         - content: |-
             #!/usr/bin/env bash
             set -x
-            if [[ "${ANDROID_VERSION_NAME}" != '"2.0"' ]]; then
-                echo 'Invalid ANDROID_VERSION_NAME, should be: "2.0"'
+            if [[ "${ANDROID_VERSION_NAME}" != '2.0' ]]; then
+                echo 'Invalid ANDROID_VERSION_NAME, should be: 2.0'
                 exit 1
             elif (( ${ANDROID_VERSION_CODE} != 2 )); then
                 echo "Invalid ANDROID_VERSION_CODE, should be: 2"
@@ -65,8 +65,8 @@ workflows:
             #!/usr/bin/env bash
             set -x
 
-            if [[ "${ANDROID_VERSION_NAME}" != '"4.0"' ]]; then
-                echo 'Invalid ANDROID_VERSION_NAME, should be: "4.0"'
+            if [[ "${ANDROID_VERSION_NAME}" != '4.0' ]]; then
+                echo 'Invalid ANDROID_VERSION_NAME, should be: 4.0'
                 exit 1
             elif (( ${ANDROID_VERSION_CODE} != 4 )); then
                 echo "Invalid ANDROID_VERSION_CODE, should be: 4"

--- a/main.go
+++ b/main.go
@@ -171,7 +171,7 @@ func main() {
 	//
 	// export outputs
 	if err := exportOutputs(map[string]string{
-		"ANDROID_VERSION_NAME": res.FinalVersionName,
+		"ANDROID_VERSION_NAME": removeQuotationMarks(res.FinalVersionName),
 		"ANDROID_VERSION_CODE": res.FinalVersionCode,
 	}); err != nil {
 		failf("Failed to export outputs, error: %s", err)
@@ -184,4 +184,8 @@ func main() {
 	fmt.Println()
 	log.Donef("%d versionCode updated", res.UpdatedVersionCodes)
 	log.Donef("%d versionName updated", res.UpdatedVersionNames)
+}
+
+func removeQuotationMarks(value string) string {
+	return strings.Trim(value, `"'`)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -198,3 +198,39 @@ func TestBuildGradleVersionUpdater_UpdateVersion(t *testing.T) {
 		})
 	}
 }
+
+func Test_removeQuotationMarks(t *testing.T) {
+	tests := []struct {
+		name string
+		args string
+		want string
+	}{
+		{
+			name: "Nothing to remove",
+			args: `FooBar`,
+			want: `FooBar`,
+		},
+		{
+			name: "Single Quote",
+			args: `'FooBar'`,
+			want: `FooBar`,
+		},
+		{
+			name: "Double Quote",
+			args: `"FooBar"`,
+			want: `FooBar`,
+		},
+		{
+			name: "Stress",
+			args: `"'"FooBar'"''`,
+			want: `FooBar`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := removeQuotationMarks(tt.args); got != tt.want {
+				t.Errorf("removeQuotationMarks() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Checklist

- [✅] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _MINOR_ [version update](https://semver.org/)

### Context

Exported version name output included quotation marks which don't make sense. We will remove it.

Resolves: #35

### Changes

- Remove quotation marks from the version name output

### Decisions

Releasing this change as `MINOR` because the old behavior was probably not exploited in the current workflows
