### PR TITLE
Zero

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ const (
 type config struct {
 	BuildGradlePth    string `env:"build_gradle_path,file"`
 	NewVersionName    string `env:"new_version_name"`
-	NewVersionCode    int    `env:"new_version_code,range]0..2100000000]"`
+	NewVersionCode    int    `env:"new_version_code,range[0..2100000000]"`
 	VersionCodeOffset int    `env:"version_code_offset"`
 }
 
@@ -101,7 +101,7 @@ func (u BuildGradleVersionUpdater) UpdateVersion(newVersionCode, versionCodeOffs
 			res.FinalVersionCode = oldVersionCode
 			updatedLine := ""
 
-			if newVersionCode > 0 {
+			if (newVersionCode + versionCodeOffset) > 0 {
 				res.FinalVersionCode = strconv.Itoa(newVersionCode + versionCodeOffset)
 				updatedLine = strings.Replace(line, oldVersionCode, res.FinalVersionCode, -1)
 				res.UpdatedVersionCodes++
@@ -148,8 +148,8 @@ func main() {
 	stepconf.Print(cfg)
 	fmt.Println()
 
-	if cfg.NewVersionName == "" && cfg.NewVersionCode == 0 {
-		failf("Neither NewVersionCode nor NewVersionName are provided, however one of them is required.")
+	if cfg.NewVersionName == "" && cfg.NewVersionCode == 0 && cfg.VersionCodeOffset == 0 {
+		failf("Neither NewVersionName nor a valid NewVersionCode is provided, however one of them is required.")
 	}
 
 	//

--- a/main_test.go
+++ b/main_test.go
@@ -126,7 +126,15 @@ func TestBuildGradleVersionUpdater_UpdateVersion(t *testing.T) {
 			name:              "versionCode needs to be a positive integer",
 			buildGradleReader: strings.NewReader("versionCode 1"),
 			newVersionCode:    0,
+			versionCodeOffset: 0,
 			want:              UpdateResult{NewContent: "versionCode 1", FinalVersionCode: "1"},
+		},
+		{
+			name:              "versionCode needs to be a positive integer",
+			buildGradleReader: strings.NewReader("versionCode 1"),
+			newVersionCode:    0,
+			versionCodeOffset: 10,
+			want:              UpdateResult{NewContent: "versionCode 10", FinalVersionCode: "10", UpdatedVersionCodes: 1},
 		},
 		{
 			name:              "Does not touch ABI version code mapping",

--- a/step.yml
+++ b/step.yml
@@ -77,7 +77,7 @@ inputs:
         New versionCode to set.  
         Specify a positive integer value, such as `1`.  
         The greatest value Google Play allows for versionCode is 2100000000.  
-        Clear this input's default value to leave the versionCode unchanged.
+        Clear this input's default value to leave the versionCode unchanged.  
         The default value is 0.
   - version_code_offset:
     opts:
@@ -86,7 +86,7 @@ inputs:
         Offset value to add to `New versionCode`.
       description: |-
         Offset value to add to `New versionCode`, for example: `1`.  
-        Leave this input empty if you want the exact value you set in `New versionCode` input.
+        Leave this input empty if you want the exact value you set in `New versionCode` input.  
         The default value is 0.
 outputs:
   - ANDROID_VERSION_NAME:

--- a/step.yml
+++ b/step.yml
@@ -78,6 +78,7 @@ inputs:
         Specify a positive integer value, such as `1`.  
         The greatest value Google Play allows for versionCode is 2100000000.  
         Clear this input's default value to leave the versionCode unchanged.
+        The default value is 0.
   - version_code_offset:
     opts:
       title: versionCode Offset
@@ -86,6 +87,7 @@ inputs:
       description: |-
         Offset value to add to `New versionCode`, for example: `1`.  
         Leave this input empty if you want the exact value you set in `New versionCode` input.
+        The default value is 0.
 outputs:
   - ANDROID_VERSION_NAME:
     opts:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a PATCH [version update](https://semver.org/)

### Context

Sometimes, it is required that the counting for the new version starts from the offset without any increments.

N/A

### Changes

0 is a valid new version, provided that the offset is greater than zero.

### Investigation details

Starting from the incremented number and violating the chosen number scheme is an alternative. So is decoupling the chosen number scheme from the Step's internal implementation and updating the added number as a new version while keeping the offset empty.

### Decisions

Add support for the edge case where the new version is 0 and there is a positive number as an offset.
