### PR TITLE
Match whitespaces for complex expressions

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,9 +17,9 @@ import (
 
 const (
 	// versionCode — A positive integer [...] -> https://developer.android.com/studio/publish/versioning
-	versionCodeRegexPattern = `^versionCode(?:\s|=)+(.*?)(?:\s*\/\/.*)?$`
+	versionCodeRegexPattern = `^versionCode(?:\s|=)+(.*?)\s*(?:\/\/.*)?$`
 	// versionName — A string used as the version number shown to users [...] -> https://developer.android.com/studio/publish/versioning
-	versionNameRegexPattern = `^versionName(?:\s|=)+(.*?)(?:\s*\/\/.*)?$`
+	versionNameRegexPattern = `^versionName(?:\s|=)+(.*?)\s*(?:\/\/.*)?$`
 )
 
 type config struct {

--- a/main.go
+++ b/main.go
@@ -17,9 +17,9 @@ import (
 
 const (
 	// versionCode — A positive integer [...] -> https://developer.android.com/studio/publish/versioning
-	versionCodeRegexPattern = `^versionCode(?:\s|=)+(.*?)(?:\s|\/\/|$)`
+	versionCodeRegexPattern = `^versionCode(?:\s|=)+(.*?)(?:\s*\/\/.*)?$`
 	// versionName — A string used as the version number shown to users [...] -> https://developer.android.com/studio/publish/versioning
-	versionNameRegexPattern = `^versionName(?:=|\s)+(.*?)(?:\s|\/\/|$)`
+	versionNameRegexPattern = `^versionName(?:\s|=)+(.*?)(?:\s*\/\/.*)?$`
 )
 
 type config struct {

--- a/main_test.go
+++ b/main_test.go
@@ -26,6 +26,7 @@ func Test_regexPatterns(t *testing.T) {
 	}{
 		// versionCode regex
 		{`versionCode 1`, "1", versionCodeRegexPattern},
+		{`versionCode 1    `, "1", versionCodeRegexPattern},
 		{`versionCode 1//close comment`, "1", versionCodeRegexPattern},
 		{`versionCode 1 // far comment`, "1", versionCodeRegexPattern},
 		{`versionCode myWar`, "myWar", versionCodeRegexPattern},
@@ -51,6 +52,7 @@ func Test_regexPatterns(t *testing.T) {
 
 		// versionName regex
 		{`versionName "1.0"`, `"1.0"`, versionNameRegexPattern},
+		{`versionName "1.0"   `, `"1.0"`, versionNameRegexPattern},
 		{`versionName "1.0"//close comment`, `"1.0"`, versionNameRegexPattern},
 		{`versionName "1.0" // far comment`, `"1.0"`, versionNameRegexPattern},
 		{`versionName '1.0'`, `'1.0'`, versionNameRegexPattern},

--- a/main_test.go
+++ b/main_test.go
@@ -31,6 +31,11 @@ func Test_regexPatterns(t *testing.T) {
 		{`versionCode myWar`, "myWar", versionCodeRegexPattern},
 		{`versionCode myWar//close comment`, "myWar", versionCodeRegexPattern},
 		{`versionCode myWar // far comment`, "myWar", versionCodeRegexPattern},
+		{
+			`versionCode 100+Integer.parseInt('git rev-list HEAD --count'.execute().text.trim())`,
+			"100+Integer.parseInt('git rev-list HEAD --count'.execute().text.trim())",
+			versionCodeRegexPattern,
+		},
 
 		{`versionCode = 1`, "1", versionCodeRegexPattern},
 		{`versionCode =1//close comment`, "1", versionCodeRegexPattern},
@@ -38,20 +43,11 @@ func Test_regexPatterns(t *testing.T) {
 		{`versionCode = myWar`, "myWar", versionCodeRegexPattern},
 		{`versionCode   =  myWar//close comment`, "myWar", versionCodeRegexPattern},
 		{`versionCode  = myWar // far comment`, "myWar", versionCodeRegexPattern},
-
-		{`versionCode 1` + "\n", "1", versionCodeRegexPattern},
-		{`versionCode 1//close comment` + "\n", "1", versionCodeRegexPattern},
-		{`versionCode 1 // far comment` + "\n", "1", versionCodeRegexPattern},
-		{`versionCode myWar` + "\n", "myWar", versionCodeRegexPattern},
-		{`versionCode myWar//close comment` + "\n", "myWar", versionCodeRegexPattern},
-		{`versionCode myWar // far comment` + "\n", "myWar", versionCodeRegexPattern},
-
-		{`versionCode = 1` + "\n", "1", versionCodeRegexPattern},
-		{`versionCode =1//close comment` + "\n", "1", versionCodeRegexPattern},
-		{`versionCode= 1 // far comment` + "\n", "1", versionCodeRegexPattern},
-		{`versionCode = myWar` + "\n", "myWar", versionCodeRegexPattern},
-		{`versionCode   =  myWar//close comment` + "\n", "myWar", versionCodeRegexPattern},
-		{`versionCode  = myWar // far comment` + "\n", "myWar", versionCodeRegexPattern},
+		{
+			`versionCode=100+Integer.parseInt('git rev-list HEAD --count'.execute().text.trim())`,
+			"100+Integer.parseInt('git rev-list HEAD --count'.execute().text.trim())",
+			versionCodeRegexPattern,
+		},
 
 		// versionName regex
 		{`versionName "1.0"`, `"1.0"`, versionNameRegexPattern},
@@ -66,24 +62,7 @@ func Test_regexPatterns(t *testing.T) {
 		{`versionName myWar//close comment`, "myWar", versionNameRegexPattern},
 		{`versionName myWar // far comment`, "myWar", versionNameRegexPattern},
 		{`versionName = myWar // far comment`, "myWar", versionNameRegexPattern},
-
-		{`versionName "1.0"` + "\n", `"1.0"`, versionNameRegexPattern},
-		{`versionName "1.0"//close comment` + "\n", `"1.0"`, versionNameRegexPattern},
-		{`versionName="1.0" // far comment` + "\n", `"1.0"`, versionNameRegexPattern},
-		{`versionName '1.0'` + "\n", `'1.0'`, versionNameRegexPattern},
-		{`versionName '1.0'//close comment` + "\n", `'1.0'`, versionNameRegexPattern},
-		{`versionName '1.0' // far comment` + "\n", `'1.0'`, versionNameRegexPattern},
-		{`versionName = '1.0' // far comment` + "\n", `'1.0'`, versionNameRegexPattern},
-
-		{`versionName myWar` + "\n", "myWar", versionNameRegexPattern},
-		{`versionName myWar//close comment` + "\n", "myWar", versionNameRegexPattern},
-		{`versionName myWar // far comment` + "\n", "myWar", versionNameRegexPattern},
-		{`versionName = myWar // far comment` + "\n", "myWar", versionNameRegexPattern},
-
-		{`versionName myWar` + "\n", "myWar", versionNameRegexPattern},
-		{`versionName myWar//close comment` + "\n", "myWar", versionNameRegexPattern},
-		{`versionName myWar // far comment` + "\n", "myWar", versionNameRegexPattern},
-		{`versionName=myWar // far comment` + "\n", "myWar", versionNameRegexPattern},
+		{`versionName=myWar // far comment`, "myWar", versionNameRegexPattern},
 	} {
 		t.Run(tt.sampleContent, func(t *testing.T) {
 			got := regexp.MustCompile(tt.regexPattern).FindStringSubmatch(tt.sampleContent)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MINOR* [version update](https://semver.org/)

### Context

Upgraded regexp to explicitely match the optional command and end-of-text (line), this allows to match whitespaces in the version code "expression".
Removed test cases with newline -> I think these are not needed as we scan the file line by line anyway.
<!--- 
  One sentence summary on why the change is needed.
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
